### PR TITLE
feat: show missing interpolation

### DIFF
--- a/lib/mustache.ex
+++ b/lib/mustache.ex
@@ -26,10 +26,10 @@ defmodule Mustache do
           key = String.replace(variable, "&", "") |> String.trim
           data |> indifferent_access(key) |> to_string
         end
-        if value == nil do
-          template
-        else
-          double_mustaches(String.replace(template, "{{#{variable}}}", value), data)
+        case value do
+          nil -> template
+          "" -> double_mustaches(String.replace(template, "{{#{variable}}}", "**#{variable}**"), data)
+          _ -> double_mustaches(String.replace(template, "{{#{variable}}}", value), data)
         end
     end
   end

--- a/test/mustache_feature_test.exs
+++ b/test/mustache_feature_test.exs
@@ -46,7 +46,7 @@ defmodule MustacheFeatureTest do
   end
 
   test "Basic Context Miss Interpolation" do
-    assert Mustache.render("I ({{cannot}}) be seen!", %{}) == "I () be seen!"
+    assert Mustache.render("I ({{can}}) be seen!", %{}) == "I (**can**) be seen!"
   end
 
   test "Triple Mustache Context Miss Interpolation" do
@@ -54,7 +54,7 @@ defmodule MustacheFeatureTest do
   end
 
   test "Ampersand Context Miss Interpolation" do
-    assert Mustache.render("I ({{&cannot}}) be seen!", %{}) == "I () be seen!"
+    assert Mustache.render("I ({{&can}}) be seen!", %{}) == "I (**&can**) be seen!"
   end
 
   #Dotted Names


### PR DESCRIPTION
We need to visualize the missing tag while creating documents without bookings, therefore this PR substitutes the empty string replacer on missing interpolation with double stars (**) until we find a better solution.

It is no so straightforward to keep the curly braces "({{}}))" because Mustache does a recursive search and keep trying to replace anything between the mustaches.