### PR TITLE
feat: for missing key names, use a format that looks more technical

### DIFF
--- a/lib/mustache.ex
+++ b/lib/mustache.ex
@@ -169,20 +169,8 @@ defmodule Mustache do
   defp blank?(""), do: true
   defp blank?(_), do: false
 
-  defp humanize_key(key) do
-    key
-    |> String.replace("_", " ")
-    |> String.capitalize()
-  end
-
   defp format_missing_key(path) do
-    humanized =
-      path
-      |> String.split(".")
-      |> Enum.map(&humanize_key/1)
-      |> Enum.join(" > ")
-
-    "[[#{humanized}]]"
+    "[[#{path}]]"
   end
 
   defp strategies do

--- a/test/mustache_feature_test.exs
+++ b/test/mustache_feature_test.exs
@@ -46,7 +46,7 @@ defmodule MustacheFeatureTest do
   end
 
   test "Basic Context Miss Interpolation" do
-    assert Mustache.render("I ({{can}}) be seen!", %{}) == "I ([[Can]]) be seen!"
+    assert Mustache.render("I ({{can}}) be seen!", %{}) == "I ([[can]]) be seen!"
   end
 
   test "Triple Mustache Context Miss Interpolation" do
@@ -54,7 +54,7 @@ defmodule MustacheFeatureTest do
   end
 
   test "Ampersand Context Miss Interpolation" do
-    assert Mustache.render("I ({{&can}}) be seen!", %{}) == "I ([[Can]]) be seen!"
+    assert Mustache.render("I ({{&can}}) be seen!", %{}) == "I ([[can]]) be seen!"
   end
 
   #Dotted Names

--- a/test/mustache_integration_test.exs
+++ b/test/mustache_integration_test.exs
@@ -47,22 +47,22 @@ defmodule MustacheTest do
 
   test "Renders human readable placeholders for missing keys" do
     # Basics
-    assert Mustache.render("Hello {{name}}", %{}) == "Hello [[Name]]"
+    assert Mustache.render("Hello {{name}}", %{}) == "Hello [[name]]"
 
     assert Mustache.render("Hello {{contact.first_name}}", %{}) ==
-             "Hello [[Contact > First name]]"
+             "Hello [[contact.first_name]]"
 
     assert Mustache.render("Hello {{contact.first_name}}", %{contact: %{first_name: "John"}}) ==
              "Hello John"
 
     # Complex examples
     assert Mustache.render("Hello {{contact.first_name}}", %{contact: %{}}) ==
-             "Hello [[Contact > First name]]"
+             "Hello [[contact.first_name]]"
 
     assert Mustache.render("Hello {{contact.first_name}}", %{contact: %{first_name: ""}}) ==
-             "Hello [[Contact > First name]]"
+             "Hello [[contact.first_name]]"
 
     assert Mustache.render("Hello {{contact.first_name}}", %{contact: %{first_name: nil}}) ==
-             "Hello [[Contact > First name]]"
+             "Hello [[contact.first_name]]"
   end
 end


### PR DESCRIPTION
The previous version looks too much like normal text, and it's hard to read in complicated contexts. This is more direct. 